### PR TITLE
log server errors

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ const Sentry = require('@sentry/node');
 
 module.exports = (sentryOptions) => ({
   onError(handler, next) {
-    if (!handler.error.statusCode) {
+    if (!handler.error.statusCode || handler.error.statusCode >= 500) {
       Sentry.init(sentryOptions);
 
       Sentry.configureScope((scope) => {


### PR DESCRIPTION
This will report http errors, if the status code is 5xx. We want to report in those cases because those are server errors.